### PR TITLE
feat: drive SO-100 servos from iPhone via FeetechArmController

### DIFF
--- a/server/feetech_controller.py
+++ b/server/feetech_controller.py
@@ -1,0 +1,246 @@
+"""Feetech STS3215 arm controller — drives the SO-100/SO-101 follower arm.
+
+Maps iPhone-sourced joint angles (radians, plus 0–1 gripper) to servo tick
+positions via a per-joint ``JointConfig`` (center tick, ticks-per-radian,
+direction, soft min/max). Writes are rate-limited and run in an executor
+thread so the WebSocket event loop never blocks on serial I/O.
+
+Servos that don't respond at connect time are skipped silently — that
+means a partially-populated arm still works for whatever channels are
+present.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import time
+from dataclasses import dataclass
+
+from scservo_sdk import PortHandler, PacketHandler, COMM_SUCCESS
+
+from .arm_controller import ArmController
+from .protocol import ArmAngles, TrackingStatus
+
+log = logging.getLogger(__name__)
+
+# STS3215 register addresses
+ADDR_TORQUE_ENABLE = 0x28
+ADDR_GOAL_ACC = 0x29
+ADDR_GOAL_POSITION = 0x2A
+ADDR_GOAL_SPEED = 0x2E
+ADDR_PRESENT_POSITION = 0x38
+
+DEFAULT_BAUD = 1_000_000
+SOFT_LIMIT_TICKS = 600  # ±~53° from home — conservative travel envelope
+TICKS_PER_REV = 4096
+TICKS_PER_RAD = TICKS_PER_REV / (2 * math.pi)
+
+
+@dataclass(frozen=True, slots=True)
+class JointConfig:
+    """How a single iPhone channel maps to a single servo.
+
+    ``center_tick`` is the servo position when the input angle is zero.
+    ``direction`` is +1 or -1 to flip rotation sense.
+    ``min_tick`` / ``max_tick`` clamp the final commanded position to
+    keep the arm inside safe joint limits regardless of input.
+    """
+
+    servo_id: int
+    center_tick: int
+    direction: int = 1
+    min_tick: int = 0
+    max_tick: int = TICKS_PER_REV - 1
+
+    def angle_to_tick(self, angle_rad: float) -> int:
+        raw = self.center_tick + int(self.direction * angle_rad * TICKS_PER_RAD)
+        return max(self.min_tick, min(self.max_tick, raw))
+
+
+# Default SO-100 mapping. Center ticks are placeholders — for a real arm
+# you'd calibrate by reading the "home" position of each servo. Soft limits
+# are conservative (±60° from center) and should be tightened per joint.
+DEFAULT_JOINTS: dict[str, JointConfig] = {
+    "shoulder_yaw":   JointConfig(servo_id=1, center_tick=2048, direction=+1),
+    "shoulder_pitch": JointConfig(servo_id=2, center_tick=2048, direction=+1),
+    "elbow_pitch":    JointConfig(servo_id=3, center_tick=2048, direction=+1),
+    "wrist_pitch":    JointConfig(servo_id=4, center_tick=2048, direction=+1),
+    "wrist_roll":     JointConfig(servo_id=5, center_tick=2048, direction=+1),
+}
+
+# Gripper is special: 0-1 fraction, not radians. Maps linearly between
+# closed_tick and open_tick.
+GRIPPER_SERVO_ID = 6
+GRIPPER_CLOSED_TICK = 2048
+GRIPPER_OPEN_TICK = 2700
+
+WRITE_INTERVAL_S = 0.04   # cap servo write rate at 25 Hz
+GOAL_SPEED = 1500         # ticks/sec — moderate; ~130°/sec
+GOAL_ACC = 50             # gentle ramp
+
+
+class FeetechArmController(ArmController):
+    """Drives Feetech STS3215 servos from streamed iPhone joint angles."""
+
+    def __init__(
+        self,
+        port_name: str,
+        baud: int = DEFAULT_BAUD,
+        joints: dict[str, JointConfig] | None = None,
+    ) -> None:
+        self._port_name = port_name
+        self._baud = baud
+        self._joints = joints or DEFAULT_JOINTS
+        self._port: PortHandler | None = None
+        self._packet: PacketHandler | None = None
+        self._present_ids: set[int] = set()
+        self._last_write: float = 0.0
+        self._last_debug: float = 0.0
+        self._reference: ArmAngles | None = None  # locked on first body:OK frame
+
+    # --- lifecycle -----------------------------------------------------
+
+    def connect(self) -> None:
+        """Open the serial port and discover which servos respond."""
+        port = PortHandler(self._port_name)
+        if not port.openPort():
+            raise RuntimeError(f"Failed to open {self._port_name}")
+        if not port.setBaudRate(self._baud):
+            port.closePort()
+            raise RuntimeError(f"Failed to set baud {self._baud}")
+        packet = PacketHandler(0)
+
+        # Ping every joint's servo + the gripper
+        all_ids = {cfg.servo_id for cfg in self._joints.values()} | {GRIPPER_SERVO_ID}
+        present: set[int] = set()
+        for sid in sorted(all_ids):
+            _, comm, _ = packet.ping(port, sid)
+            if comm == COMM_SUCCESS:
+                present.add(sid)
+        log.info("Found servos: %s (expected %s)", sorted(present), sorted(all_ids))
+
+        # Read live home positions and rewrite each joint's center so
+        # iPhone "zero angle" maps to "stay where you are now" instead of
+        # snapping to a hardcoded tick. Also clamp soft limits around home.
+        for name, cfg in list(self._joints.items()):
+            if cfg.servo_id not in present:
+                continue
+            pos, comm, _ = packet.read2ByteTxRx(port, cfg.servo_id, ADDR_PRESENT_POSITION)
+            if comm != COMM_SUCCESS:
+                continue
+            self._joints[name] = JointConfig(
+                servo_id=cfg.servo_id,
+                center_tick=pos,
+                direction=cfg.direction,
+                min_tick=max(0, pos - SOFT_LIMIT_TICKS),
+                max_tick=min(TICKS_PER_REV - 1, pos + SOFT_LIMIT_TICKS),
+            )
+            log.info("ID %d (%s): home=%d, soft-limits=[%d,%d]",
+                     cfg.servo_id, name, pos,
+                     self._joints[name].min_tick, self._joints[name].max_tick)
+
+        # Enable torque on responders, set speed/acc limits
+        for sid in present:
+            packet.write1ByteTxRx(port, sid, ADDR_GOAL_ACC, GOAL_ACC)
+            packet.write2ByteTxRx(port, sid, ADDR_GOAL_SPEED, GOAL_SPEED)
+            packet.write1ByteTxRx(port, sid, ADDR_TORQUE_ENABLE, 1)
+
+        self._port = port
+        self._packet = packet
+        self._present_ids = present
+
+    def disconnect(self) -> None:
+        """Disable torque on all servos and close the port (safe limp state)."""
+        if self._port and self._packet:
+            for sid in self._present_ids:
+                try:
+                    self._packet.write1ByteTxRx(self._port, sid, ADDR_TORQUE_ENABLE, 0)
+                except Exception as exc:  # noqa: BLE001
+                    log.warning("Torque-off failed for ID %d: %s", sid, exc)
+            self._port.closePort()
+        self._port = None
+        self._packet = None
+        self._present_ids = set()
+
+    # --- ArmController interface --------------------------------------
+
+    async def update(self, angles: ArmAngles, tracking: TrackingStatus) -> None:
+        now = time.monotonic()
+        # Periodic debug ping so we can see whether updates are arriving
+        # and why we might be skipping them.
+        if now - self._last_debug > 1.0:
+            log.info("rx: %s | %s", angles.degrees_str(), tracking)
+            self._last_debug = now
+
+        if now - self._last_write < WRITE_INTERVAL_S:
+            return
+        self._last_write = now
+
+        # Lock a reference pose on the first body:OK frame so subsequent
+        # angles are sent as deltas — your "neutral" body posture becomes
+        # the arm's home position.
+        if tracking.body and self._reference is None:
+            self._reference = angles
+            log.info("Reference pose locked: %s", angles.degrees_str())
+
+        relative = self._relative(angles) if self._reference else angles
+
+        # Body tracking drives the arm joints; hand tracking drives the
+        # gripper. Either can be active independently.
+        targets = self._build_targets(relative, drive_arm=tracking.body, drive_gripper=tracking.hand)
+        if targets:
+            await asyncio.to_thread(self._write_targets, targets)
+
+    async def stop(self) -> None:
+        await asyncio.to_thread(self.disconnect)
+
+    # --- internals -----------------------------------------------------
+
+    def _relative(self, angles: ArmAngles) -> ArmAngles:
+        """Subtract the reference pose from a fresh frame. Gripper passes through."""
+        r = self._reference
+        assert r is not None  # caller checked
+        return ArmAngles(
+            shoulder_yaw=angles.shoulder_yaw - r.shoulder_yaw,
+            shoulder_pitch=angles.shoulder_pitch - r.shoulder_pitch,
+            elbow_pitch=angles.elbow_pitch - r.elbow_pitch,
+            wrist_pitch=angles.wrist_pitch - r.wrist_pitch,
+            wrist_roll=angles.wrist_roll - r.wrist_roll,
+            gripper=angles.gripper,
+        )
+
+    def _build_targets(
+        self,
+        angles: ArmAngles,
+        drive_arm: bool = True,
+        drive_gripper: bool = True,
+    ) -> list[tuple[int, int]]:
+        """Convert an ArmAngles into (servo_id, goal_tick) pairs."""
+        out: list[tuple[int, int]] = []
+        if drive_arm:
+            channels = {
+                "shoulder_yaw": angles.shoulder_yaw,
+                "shoulder_pitch": angles.shoulder_pitch,
+                "elbow_pitch": angles.elbow_pitch,
+                "wrist_pitch": angles.wrist_pitch,
+                "wrist_roll": angles.wrist_roll,
+            }
+            for name, angle in channels.items():
+                cfg = self._joints.get(name)
+                if cfg is None or cfg.servo_id not in self._present_ids:
+                    continue
+                out.append((cfg.servo_id, cfg.angle_to_tick(angle)))
+
+        if drive_gripper and GRIPPER_SERVO_ID in self._present_ids:
+            g = max(0.0, min(1.0, angles.gripper))
+            tick = int(GRIPPER_CLOSED_TICK + g * (GRIPPER_OPEN_TICK - GRIPPER_CLOSED_TICK))
+            out.append((GRIPPER_SERVO_ID, tick))
+        return out
+
+    def _write_targets(self, targets: list[tuple[int, int]]) -> None:
+        if self._port is None or self._packet is None:
+            return
+        for sid, tick in targets:
+            self._packet.write2ByteTxRx(self._port, sid, ADDR_GOAL_POSITION, tick)

--- a/server/scripts/deep_scan.py
+++ b/server/scripts/deep_scan.py
@@ -1,0 +1,55 @@
+"""Deep scan for Feetech servos.
+
+Pings every ID from 1 to 253 at 1 Mbaud, three times each, and reports
+which IDs answer at least once. This catches:
+  - servos configured to non-default IDs (factory default is 1)
+  - servos with intermittent comms (only some pings succeed)
+  - the actual model number of each servo
+
+Use this when scan_bus.py finds fewer servos than expected.
+"""
+from __future__ import annotations
+
+import sys
+
+from scservo_sdk import PortHandler, PacketHandler, COMM_SUCCESS
+
+PORT = sys.argv[1] if len(sys.argv) > 1 else "/dev/cu.usbmodem5A4B0468521"
+BAUD = 1_000_000
+PINGS_PER_ID = 3
+
+
+def main() -> int:
+    port = PortHandler(PORT)
+    if not port.openPort() or not port.setBaudRate(BAUD):
+        print(f"Failed to open {PORT} @ {BAUD}")
+        return 1
+    packet = PacketHandler(0)
+
+    print(f"Pinging IDs 1-253 at {BAUD} baud, {PINGS_PER_ID}x each...\n")
+    print(f"{'ID':>4}  {'hits':>5}  {'model':>8}  {'err':>4}")
+    print("-" * 30)
+
+    found = 0
+    for sid in range(1, 254):
+        hits = 0
+        last_model = 0
+        last_err = 0
+        for _ in range(PINGS_PER_ID):
+            model, comm, err = packet.ping(port, sid)
+            if comm == COMM_SUCCESS:
+                hits += 1
+                last_model = model
+                last_err = err
+        if hits:
+            found += 1
+            tag = " OK " if hits == PINGS_PER_ID else "flaky"
+            print(f"{sid:>4}  {hits}/{PINGS_PER_ID} {tag}  0x{last_model:04X}  0x{last_err:02X}")
+
+    print(f"\nTotal: {found} servo(s) responded.")
+    port.closePort()
+    return 0 if found else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/scripts/raw_probe.py
+++ b/server/scripts/raw_probe.py
@@ -1,0 +1,63 @@
+"""Low-level Feetech bus probe — bypass the SDK and dump raw bytes.
+
+Sends a hand-built broadcast PING packet at 1 Mbaud and shows every byte
+that comes back. Useful when the SDK's ping() returns nothing and we need
+to know whether the bus is electrically dead, sending garbage, or just
+using a baud rate we haven't tried.
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+import serial
+
+PORT = sys.argv[1] if len(sys.argv) > 1 else "/dev/cu.usbmodem5B141154581"
+BAUDS = [1_000_000, 2_000_000, 500_000, 250_000, 128_000, 115_200, 76_800, 57_600, 38_400, 19_200, 9600, 4800]
+
+
+def ping_packet(servo_id: int) -> bytes:
+    """Build a Feetech/Dynamixel-style PING: FF FF ID LEN INST CHKSUM."""
+    length = 0x02
+    inst = 0x01  # PING
+    checksum = (~(servo_id + length + inst)) & 0xFF
+    return bytes([0xFF, 0xFF, servo_id, length, inst, checksum])
+
+
+def probe(baud: int) -> bytes:
+    s = serial.Serial(PORT, baud, timeout=0.1)
+    try:
+        # Broadcast ping (ID 0xFE) — every servo on the bus should reply
+        for sid in (0xFE, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06):
+            s.reset_input_buffer()
+            pkt = ping_packet(sid)
+            s.write(pkt)
+            s.flush()
+            time.sleep(0.05)
+            data = s.read(64)
+            if data:
+                return data
+        return b""
+    finally:
+        s.close()
+
+
+def main() -> int:
+    print(f"Probing {PORT}")
+    for baud in BAUDS:
+        try:
+            data = probe(baud)
+        except serial.SerialException as e:
+            print(f"  baud {baud}: open failed: {e}")
+            continue
+        if data:
+            print(f"  baud {baud}: RX {len(data)} bytes: {data.hex(' ')}")
+            return 0
+        else:
+            print(f"  baud {baud}: silent")
+    print("\nNo bytes returned at any baud. Bus is electrically silent.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/scripts/scan_bus.py
+++ b/server/scripts/scan_bus.py
@@ -1,0 +1,44 @@
+"""Scan the Feetech servo bus to discover IDs and baud rate.
+
+Pings IDs 1-20 at common SO-100 baud rates, prints what responds.
+"""
+from __future__ import annotations
+
+import sys
+from scservo_sdk import PortHandler, PacketHandler, COMM_SUCCESS
+
+PORT = sys.argv[1] if len(sys.argv) > 1 else "/dev/tty.usbmodem5B141154581"
+BAUDS = [1_000_000, 500_000, 115_200, 57_600]
+IDS = range(1, 21)
+
+
+def main() -> int:
+    port = PortHandler(PORT)
+    if not port.openPort():
+        print(f"Failed to open {PORT}")
+        return 1
+    found_any = False
+    for proto in (0, 1):
+        packet = PacketHandler(proto)
+        for baud in BAUDS:
+            if not port.setBaudRate(baud):
+                continue
+            hits = []
+            for sid in IDS:
+                model, comm, err = packet.ping(port, sid)
+                if comm == COMM_SUCCESS:
+                    hits.append((sid, model, err))
+            if hits:
+                found_any = True
+                print(f"\nproto={proto} baud={baud}:")
+                for sid, model, err in hits:
+                    print(f"  ID {sid:>2}  model=0x{model:04X}  err=0x{err:02X}")
+
+    if not found_any:
+        print("No servos found on any baud rate.")
+    port.closePort()
+    return 0 if found_any else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/scripts/wiggle.py
+++ b/server/scripts/wiggle.py
@@ -1,0 +1,101 @@
+"""Gentle wiggle test for Feetech STS3215 servos.
+
+Reads each servo's current position, applies a small random offset (~4° peak)
+at low speed, holds for a beat, then returns to the original position and
+disables torque. Designed to confirm "the bus can drive motion" without
+swinging anything hard.
+"""
+from __future__ import annotations
+
+import random
+import sys
+import time
+
+from scservo_sdk import PortHandler, PacketHandler, COMM_SUCCESS
+
+# STS3215 register addresses
+ADDR_TORQUE_ENABLE = 0x28      # 1 byte
+ADDR_GOAL_ACC = 0x29           # 1 byte (acceleration limit)
+ADDR_GOAL_POSITION = 0x2A      # 2 bytes, 0-4095 = 0-360°
+ADDR_GOAL_SPEED = 0x2E         # 2 bytes (steps/sec, 0 = max)
+ADDR_PRESENT_POSITION = 0x38   # 2 bytes (read-only)
+
+PORT = sys.argv[1] if len(sys.argv) > 1 else "/dev/cu.usbmodem5A4B0468521"
+BAUD = 1_000_000
+IDS = [3, 4, 6]               # discovered by scan_bus.py
+WIGGLE_TICKS = 50             # ~4° peak (4096 ticks / 360°)
+WIGGLE_SPEED = 200            # very slow — steps/sec
+WIGGLE_ACC = 20               # gentle acceleration
+HOLD_SECONDS = 1.0
+
+
+def read_position(packet, port, sid: int) -> int | None:
+    val, comm, _ = packet.read2ByteTxRx(port, sid, ADDR_PRESENT_POSITION)
+    return val if comm == COMM_SUCCESS else None
+
+
+def set_torque(packet, port, sid: int, on: bool) -> None:
+    packet.write1ByteTxRx(port, sid, ADDR_TORQUE_ENABLE, 1 if on else 0)
+
+
+def write_goal(packet, port, sid: int, position: int, speed: int, acc: int) -> None:
+    packet.write1ByteTxRx(port, sid, ADDR_GOAL_ACC, acc)
+    packet.write2ByteTxRx(port, sid, ADDR_GOAL_SPEED, speed)
+    packet.write2ByteTxRx(port, sid, ADDR_GOAL_POSITION, position)
+
+
+def main() -> int:
+    port = PortHandler(PORT)
+    if not port.openPort() or not port.setBaudRate(BAUD):
+        print(f"Failed to open {PORT} @ {BAUD}")
+        return 1
+    packet = PacketHandler(0)
+
+    # 1. Read home positions
+    home: dict[int, int] = {}
+    for sid in IDS:
+        pos = read_position(packet, port, sid)
+        if pos is None:
+            print(f"ID {sid}: no response, skipping")
+            continue
+        home[sid] = pos
+        print(f"ID {sid}: home = {pos} ({pos * 360 / 4095:.1f}°)")
+    if not home:
+        print("No servos responding — aborting.")
+        return 1
+
+    # 2. Pick small random offset targets
+    targets: dict[int, int] = {}
+    for sid, pos in home.items():
+        offset = random.randint(-WIGGLE_TICKS, WIGGLE_TICKS)
+        targets[sid] = max(0, min(4095, pos + offset))
+        print(f"ID {sid}: target = {targets[sid]} (offset {offset:+d} ticks)")
+
+    # 3. Enable torque
+    for sid in home:
+        set_torque(packet, port, sid, True)
+
+    try:
+        # 4. Move to wiggle target
+        print("Moving to wiggle target...")
+        for sid, target in targets.items():
+            write_goal(packet, port, sid, target, WIGGLE_SPEED, WIGGLE_ACC)
+        time.sleep(HOLD_SECONDS)
+
+        # 5. Move back home
+        print("Moving back to home...")
+        for sid, pos in home.items():
+            write_goal(packet, port, sid, pos, WIGGLE_SPEED, WIGGLE_ACC)
+        time.sleep(HOLD_SECONDS)
+    finally:
+        # 6. Disable torque so the arm goes limp again (safe state)
+        for sid in home:
+            set_torque(packet, port, sid, False)
+        port.closePort()
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/scripts/wiggle_one_by_one.py
+++ b/server/scripts/wiggle_one_by_one.py
@@ -1,0 +1,73 @@
+"""Wiggle each responding servo individually so the user can watch which
+physical joint moves. For each servo: print the ID, move +50 ticks (~4°),
+hold, move -50 ticks, hold, return to home, then pause before the next one.
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+from scservo_sdk import PortHandler, PacketHandler, COMM_SUCCESS
+
+ADDR_TORQUE_ENABLE = 0x28
+ADDR_GOAL_ACC = 0x29
+ADDR_GOAL_POSITION = 0x2A
+ADDR_GOAL_SPEED = 0x2E
+ADDR_PRESENT_POSITION = 0x38
+
+PORT = sys.argv[1] if len(sys.argv) > 1 else "/dev/cu.usbmodem5A4B0468521"
+BAUD = 1_000_000
+WIGGLE_TICKS = 80     # ~7° peak — enough to see clearly
+WIGGLE_SPEED = 300    # gentle
+WIGGLE_ACC = 30
+HOLD_S = 0.7
+GAP_S = 1.2
+
+
+def main() -> int:
+    port = PortHandler(PORT)
+    if not port.openPort() or not port.setBaudRate(BAUD):
+        print(f"Failed to open {PORT}")
+        return 1
+    packet = PacketHandler(0)
+
+    # Discover responders
+    ids = []
+    for sid in range(1, 254):
+        _, comm, _ = packet.ping(port, sid)
+        if comm == COMM_SUCCESS:
+            ids.append(sid)
+    print(f"Responding servos: {ids}\n")
+    if not ids:
+        return 1
+
+    for sid in ids:
+        pos, comm, _ = packet.read2ByteTxRx(port, sid, ADDR_PRESENT_POSITION)
+        if comm != COMM_SUCCESS:
+            print(f"ID {sid}: failed to read position, skipping")
+            continue
+        home = pos
+        print(f"--- ID {sid} ---  home={home}")
+
+        packet.write1ByteTxRx(port, sid, ADDR_GOAL_ACC, WIGGLE_ACC)
+        packet.write2ByteTxRx(port, sid, ADDR_GOAL_SPEED, WIGGLE_SPEED)
+        packet.write1ByteTxRx(port, sid, ADDR_TORQUE_ENABLE, 1)
+
+        try:
+            for offset in (+WIGGLE_TICKS, -WIGGLE_TICKS, 0):
+                target = max(0, min(4095, home + offset))
+                print(f"  → {target} (offset {offset:+d})")
+                packet.write2ByteTxRx(port, sid, ADDR_GOAL_POSITION, target)
+                time.sleep(HOLD_S)
+        finally:
+            packet.write1ByteTxRx(port, sid, ADDR_TORQUE_ENABLE, 0)
+
+        time.sleep(GAP_S)
+
+    port.closePort()
+    print("\nDone.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/server.py
+++ b/server/server.py
@@ -24,6 +24,7 @@ from websockets.http11 import Request, Response
 
 from .arm_controller import ArmController, ConsoleArmController
 from .discovery import advertise, get_lan_ip
+from .feetech_controller import FeetechArmController
 from .protocol import make_pong, parse_message
 
 log = logging.getLogger(__name__)
@@ -111,8 +112,13 @@ class ArmTrackerServer:
 
         try:
             async for raw in connection:
+                # Binary frames (H.264 video) are forwarded verbatim to viewers
+                # without parsing — the controller pipeline only cares about
+                # text JSON arm_state messages.
                 if not isinstance(raw, str):
-                    continue  # ignore binary frames
+                    if self._viewers:
+                        websockets.broadcast(self._viewers, raw)
+                    continue
 
                 msg = parse_message(raw)
                 if msg is None:
@@ -135,6 +141,7 @@ class ArmTrackerServer:
 async def main(
     port: int = 8765,
     use_bonjour: bool = True,
+    feetech_port: str | None = None,
 ) -> None:
     """Start the server and block until interrupted."""
     logging.basicConfig(
@@ -143,7 +150,13 @@ async def main(
         datefmt="%H:%M:%S",
     )
 
-    controller = ConsoleArmController()
+    controller: ArmController
+    if feetech_port:
+        feetech = FeetechArmController(feetech_port)
+        await asyncio.to_thread(feetech.connect)
+        controller = feetech
+    else:
+        controller = ConsoleArmController()
     tracker = ArmTrackerServer(controller)
 
     stop_event = asyncio.Event()
@@ -191,8 +204,21 @@ def cli() -> None:
         action="store_true",
         help="Disable Bonjour/zeroconf advertisement",
     )
+    parser.add_argument(
+        "--feetech-port",
+        type=str,
+        default=None,
+        help="Serial port for Feetech servo bus (e.g. /dev/cu.usbmodem...). "
+        "If omitted, the console controller is used.",
+    )
     args = parser.parse_args()
-    asyncio.run(main(port=args.port, use_bonjour=not args.no_bonjour))
+    asyncio.run(
+        main(
+            port=args.port,
+            use_bonjour=not args.no_bonjour,
+            feetech_port=args.feetech_port,
+        )
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Wires the iPhone body/hand tracking stream end-to-end into physical STS3215 servos for the first time. The iPhone's ARKit body tracking drives arm joints (shoulder/elbow/wrist) and Vision hand tracking drives the gripper, independently — either can work standalone.

Calibration is automatic: each joint's home tick is read at connect time, and the first body:OK frame becomes the reference pose so the user's neutral posture maps to the arm's current pose with deltas driving motion from there.

Safety: ±53° soft limits per joint, 1500 ticks/s speed cap, 25 Hz write rate, serial I/O off the event loop, missing servos skipped silently.

Opt-in via `--feetech-port /dev/cu.usbmodemXXXX` — default still ConsoleArmController.

Also adds `server/scripts/` diagnostic tools used to bring up the bus (see commit message for the full list).

## Test plan
- [x] Bus scan finds servos 3, 4, 6 at 1 Mbaud
- [x] `wiggle.py` and `wiggle_one_by_one.py` move servos through small offsets and return to home
- [x] Server connects with `--feetech-port` flag and discovers servos
- [x] iPhone-driven gripper motion works while body tracking is off
- [ ] iPhone body tracking → arm motion working but accuracy limited by ARKit skeleton fit; needs iPhone-side tuning to be smooth
- [ ] Full 6-servo chain (IDs 1, 2, 5 still silent on the test arm — physical hardware investigation, separate from this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)